### PR TITLE
Fix commonName and DNS name generation

### DIFF
--- a/assets/certs/openssl-domain.cnf
+++ b/assets/certs/openssl-domain.cnf
@@ -141,7 +141,7 @@ localityName					= $ENV::CEDAR_CA_LOC
 
 organizationalUnitName			= $ENV::CEDAR_CA_ORG_UNIT
 
-commonName						= <CEDAR.COMMON_NAME>$ENV::CEDAR_CA_COMMON_NAME
+commonName						= <CEDAR.COMMON_NAME>.$ENV::CEDAR_CA_COMMON_NAME
 
 emailAddress					= $ENV::CEDAR_CA_EMAIL
 
@@ -212,7 +212,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 
 [alt_names]
-DNS.1 = <CEDAR.COMMON_NAME>
+DNS.1 = <CEDAR.COMMON_NAME>.$ENV::CEDAR_CA_COMMON_NAME
 
 [ v3_ca ]
 


### PR DESCRIPTION
When using a custom domain name and generating certs via `cedarcli cert domains` the generated certs contain wrong commonName and DNS vlaues, which causes the resource server to fail when connecting auth.<custom domain>.

In case of commonName there was just a typo with th '.' missing. In case of DNS.1 I figured out that we need full domain name.