### PR TITLE
Example check_status.sh for checking status of services in a service group

### DIFF
--- a/check_status.sh
+++ b/check_status.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# check_status.sh [Microservice|Infrastructure|Frontend|Dashboard|Frontend-non-essential]
+#
+# Checks whether services in the given group are all running, in which case writes "OK". Otherwise, if at least
+# one service fails, write "FAIL: ..." listing the services that fail.
+#
+
+shopt -s expand_aliases
+alias cedarcli='source $CEDAR_HOME/cedar-cli/cli.sh'
+
+if [[ $# -eq 0 ]] ; then
+    echo 'Please provide the name of a service group as an argument.'
+    exit 0
+fi
+
+GROUP=$1
+FOUND_GROUP=false
+ALL_OK=true
+FAILING_SERVICES=""
+
+while read -r line ; do
+    if [[ $line == *"$GROUP"* ]] ; then
+        FOUND_GROUP=true
+        continue
+    fi
+
+    if [[ $FOUND_GROUP == true ]] ; then
+        if [[ $line == *"├"* || $line == *"┡"* || $line == *"└"* ]] ; then
+            break
+        fi
+
+        if [[ $line == *"❌"* ]] ; then
+            ALL_OK=false
+            FAILING_SERVICES+=$(echo $line | awk '{print $2}')" "
+        fi
+    fi
+done < <(cedarcli server status)
+
+if [[ $FOUND_GROUP == false ]] ; then
+    echo "Invalid service group provided: $GROUP"
+    exit 0
+fi
+
+if [[ $ALL_OK == true ]] ; then
+    echo 'OK'
+else
+    echo "FAIL: $FAILING_SERVICES"
+fi


### PR DESCRIPTION
This is just to give you an idea for a possible addition to cedarcli: we have this script to check whether all services in a service group like Infrastrucure, Microservice, Frontend, etc (names used by `cedarcli server status`) are all up and running. This allows us to run `startinfrastructure` in the background and then using `check_status.sh Infrastructure` check when all infra services are up and running. If they are (the scripts report "OK"), then we can start dependent services like `startmicroservices`, and so on.